### PR TITLE
SCRUM-110 - 크롬 익스텐션 url 가져오기 기능 구현

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.59.20",
     "axios": "^1.7.9",
+    "lettercoder": "^0.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/apps/extension/src/App.tsx
+++ b/apps/extension/src/App.tsx
@@ -2,6 +2,7 @@ import { HashRouter as Router, Route, Routes } from "react-router-dom";
 
 import Layout from "./components/layout";
 import Agreement from "./pages/agreement";
+import Bookmark from "./pages/bookmark";
 import Home from "./pages/home";
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/agreement" element={<Agreement />} />
+          <Route path="/bookmark" element={<Bookmark />} />
         </Route>
       </Routes>
     </Router>

--- a/apps/extension/src/pages/agreement.tsx
+++ b/apps/extension/src/pages/agreement.tsx
@@ -23,10 +23,10 @@ const Agreement = () => {
             <br />
             것에 동의하시겠습니까?
           </h1>
-          <h2 className="text-body">네뷸라 실행을 위해선 북마크 동의를 해야합니다.</h2>
+          <h2 className="text-label">네뷸라 실행을 위해선 북마크 동의를 해야합니다.</h2>
         </div>
         <div className="space-y-2">
-          <p className="text-label">
+          <p className="text-body">
             북마크정보 수집 및 이용 동의 <span className="text-essential">*</span>
           </p>
           <p className="text-description font-medium rounded-sm border border-grey2 p-2">

--- a/apps/extension/src/pages/agreement.tsx
+++ b/apps/extension/src/pages/agreement.tsx
@@ -35,7 +35,7 @@ const Agreement = () => {
             동의하신 경우에만 서비스 이용이 가능합니다. 수집된 정보로 사용자 개개인의 북마크 기록을
             분석하고, 비슷한 관심사를 가진 다른 사용자들의 정보를 분석하여 유용한 정보를 제공합니다.
           </p>
-          <div className="text-description flex items-center gap-1">
+          <div className="text-description flex items-center gap-1 font-normal">
             <input id="agreement" type="checkbox" checked={checked} onChange={onCheck} />
             <label htmlFor="agreement">(필수) 북마크 정보 수집 및 이용에 동의합니다.</label>
           </div>

--- a/apps/extension/src/pages/bookmark.tsx
+++ b/apps/extension/src/pages/bookmark.tsx
@@ -1,0 +1,5 @@
+const Bookmark = () => {
+  return <div>Bookmark</div>;
+};
+
+export default Bookmark;

--- a/apps/extension/src/pages/bookmark.tsx
+++ b/apps/extension/src/pages/bookmark.tsx
@@ -1,5 +1,50 @@
+import { useEffect, useState } from "react";
+
+import { RectangleButton } from "@repo/ui";
+
 const Bookmark = () => {
-  return <div>Bookmark</div>;
+  const [currentTab, setCurrentTab] = useState({ url: "사이트 url", title: "사이트 title" });
+
+  const onClickAdd = () => {
+    // 백엔드에 현재 탭 정보를 전송하는 로직
+  };
+
+  useEffect(() => {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      console.log("현재 창", tabs[0].url, tabs[0].title);
+      setCurrentTab({ url: tabs[0].url!, title: tabs[0].title! });
+    });
+    chrome.tabs.onActivated.addListener(function (activeInfo) {
+      chrome.tabs.get(activeInfo.tabId, function (tab) {
+        console.log("활성화된 탭", tab.url);
+        setCurrentTab({ url: tab.url!, title: tab.title! });
+      });
+    });
+  }, []);
+
+  return (
+    <main className="h-full gap-10 flex flex-col justify-center">
+      <h1 className="text-title text-center">현재 창 정보</h1>
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <h2 className="text-subtitle">URL</h2>
+          <p className="text-body">{currentTab.url}</p>
+        </div>
+        <div className="space-y-2">
+          <h2 className="text-subtitle">Title</h2>
+          <p className="text-body">{currentTab.title}</p>
+        </div>
+      </section>
+      <RectangleButton
+        className={
+          "w-full text-white transition-colors bg-black hover:bg-opacity-90 active:bg-opacity-80"
+        }
+        onClick={onClickAdd}
+      >
+        북마크에 추가하기
+      </RectangleButton>
+    </main>
+  );
 };
 
 export default Bookmark;

--- a/apps/extension/src/pages/bookmark.tsx
+++ b/apps/extension/src/pages/bookmark.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { getHtmlText } from "@/utils/chrome";
 import { RectangleButton } from "@repo/ui";
 
 const Bookmark = () => {
@@ -7,6 +8,7 @@ const Bookmark = () => {
 
   const onClickAdd = () => {
     // 백엔드에 현재 탭 정보를 전송하는 로직
+    const html = getHtmlText();
   };
 
   useEffect(() => {

--- a/apps/extension/src/pages/bookmark.tsx
+++ b/apps/extension/src/pages/bookmark.tsx
@@ -6,9 +6,9 @@ import { RectangleButton } from "@repo/ui";
 const Bookmark = () => {
   const [currentTab, setCurrentTab] = useState({ url: "사이트 url", title: "사이트 title" });
 
-  const onClickAdd = () => {
+  const onClickAdd = async () => {
     // 백엔드에 현재 탭 정보를 전송하는 로직
-    const html = getHtmlText();
+    const html = await getHtmlText();
   };
 
   useEffect(() => {

--- a/apps/extension/src/pages/bookmark.tsx
+++ b/apps/extension/src/pages/bookmark.tsx
@@ -29,11 +29,11 @@ const Bookmark = () => {
       <section className="space-y-4">
         <div className="space-y-2">
           <h2 className="text-subtitle">URL</h2>
-          <p className="text-body">{currentTab.url}</p>
+          <p className="text-label">{currentTab.url}</p>
         </div>
         <div className="space-y-2">
           <h2 className="text-subtitle">Title</h2>
-          <p className="text-body">{currentTab.title}</p>
+          <p className="text-label">{currentTab.title}</p>
         </div>
       </section>
       <RectangleButton

--- a/apps/extension/src/pages/bookmark.tsx
+++ b/apps/extension/src/pages/bookmark.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { getHtmlText } from "@/utils/chrome";
+import { getHtmlText, updateCurrentTab } from "@/utils/chrome";
 import { RectangleButton } from "@repo/ui";
 
 const Bookmark = () => {
@@ -12,15 +12,14 @@ const Bookmark = () => {
   };
 
   useEffect(() => {
-    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-      console.log("현재 창", tabs[0].url, tabs[0].title);
-      setCurrentTab({ url: tabs[0].url!, title: tabs[0].title! });
+    updateCurrentTab(setCurrentTab);
+    chrome.tabs.onActivated.addListener(() => {
+      updateCurrentTab(setCurrentTab);
     });
-    chrome.tabs.onActivated.addListener(function (activeInfo) {
-      chrome.tabs.get(activeInfo.tabId, function (tab) {
-        console.log("활성화된 탭", tab.url);
-        setCurrentTab({ url: tab.url!, title: tab.title! });
-      });
+    chrome.tabs.onUpdated.addListener((_, changeInfo) => {
+      if (changeInfo.status === "complete") {
+        updateCurrentTab(setCurrentTab);
+      }
     });
   }, []);
 

--- a/apps/extension/src/pages/bookmark.tsx
+++ b/apps/extension/src/pages/bookmark.tsx
@@ -26,7 +26,7 @@ const Bookmark = () => {
 
   return (
     <main className="h-full gap-10 flex flex-col justify-center">
-      <h1 className="text-title text-center">현재 창 정보</h1>
+      <h1 className="text-title text-center">현재 페이지 정보</h1>
       <section className="space-y-4">
         <div className="space-y-2">
           <h2 className="text-subtitle">URL</h2>

--- a/apps/extension/src/pages/home.tsx
+++ b/apps/extension/src/pages/home.tsx
@@ -15,7 +15,7 @@ const Home = () => {
             <Logo />
           </div>
         </div>
-        <p className="text-body text-grey5">크롬 익스텐션 실행을 위해 로그인 해주세요.</p>
+        <p className="text-label text-grey5">크롬 익스텐션 실행을 위해 로그인 해주세요.</p>
       </section>
       <section className="space-y-7">
         <div className="gap-2 flex flex-col">

--- a/apps/extension/src/pages/home.tsx
+++ b/apps/extension/src/pages/home.tsx
@@ -24,7 +24,7 @@ const Home = () => {
         </div>
         <div className="text-description gap-3 flex items-center justify-center text-grey3">
           <button>이용약관</button>
-          <div className="h-3 w-px bg-black" />
+          <div className="h-3 w-px bg-grey3" />
           <button>개인정보처리방침</button>
         </div>
       </section>

--- a/apps/extension/src/utils/chrome.ts
+++ b/apps/extension/src/utils/chrome.ts
@@ -49,3 +49,11 @@ export const getHtmlText = async () => {
     });
   });
 };
+
+export const updateCurrentTab = (
+  setState: ({ url, title }: { url: string; title: string }) => void
+) => {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    setState({ url: tabs[0].url!, title: tabs[0].title! });
+  });
+};

--- a/apps/extension/src/utils/chrome.ts
+++ b/apps/extension/src/utils/chrome.ts
@@ -1,19 +1,16 @@
+import { decodeQuotedPrintable } from "lettercoder";
+
 export const searchHistory = (text: string) => {
-  chrome.history.search(
-    { text, startTime: Date.now() - 7 * 24 * 60 * 60 * 1000 },
-    (results) => {
-      console.log(results);
-    }
-  );
+  chrome.history.search({ text, startTime: Date.now() - 7 * 24 * 60 * 60 * 1000 }, (results) => {
+    console.log(results);
+  });
 };
 
 export const getBookMarks = () => {
   chrome.bookmarks.getTree((trees) => {
     const makeUp = (items: chrome.bookmarks.BookmarkTreeNode[]) => {
       return items.map(
-        (
-          item: chrome.bookmarks.BookmarkTreeNode
-        ): chrome.bookmarks.BookmarkTreeNode => {
+        (item: chrome.bookmarks.BookmarkTreeNode): chrome.bookmarks.BookmarkTreeNode => {
           if (typeof item.children !== "undefined") {
             return {
               id: item.id,
@@ -31,5 +28,18 @@ export const getBookMarks = () => {
     };
     const result = makeUp(trees)[0].children;
     console.log(result);
+  });
+};
+
+export const getHtmlText = () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.pageCapture.saveAsMHTML({ tabId: tabs[0].id as number }, async (data) => {
+      const quotedPrintableData = await data!.text();
+      const decodedData = decodeQuotedPrintable(quotedPrintableData);
+      const textDecoder = new TextDecoder("utf-8");
+      const htmlContent = textDecoder.decode(decodedData);
+
+      return htmlContent;
+    });
   });
 };

--- a/apps/extension/src/utils/chrome.ts
+++ b/apps/extension/src/utils/chrome.ts
@@ -31,15 +31,21 @@ export const getBookMarks = () => {
   });
 };
 
-export const getHtmlText = () => {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    chrome.pageCapture.saveAsMHTML({ tabId: tabs[0].id as number }, async (data) => {
-      const quotedPrintableData = await data!.text();
-      const decodedData = decodeQuotedPrintable(quotedPrintableData);
-      const textDecoder = new TextDecoder("utf-8");
-      const htmlContent = textDecoder.decode(decodedData);
+export const getHtmlText = async () => {
+  return new Promise<string>((resolve, reject) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      chrome.pageCapture.saveAsMHTML({ tabId: tabs[0].id as number }, async (data) => {
+        try {
+          const quotedPrintableData = await data!.text();
+          const decodedData = decodeQuotedPrintable(quotedPrintableData);
+          const textDecoder = new TextDecoder("utf-8");
+          const htmlContent = textDecoder.decode(decodedData);
 
-      return htmlContent;
+          resolve(htmlContent);
+        } catch (error) {
+          reject(error);
+        }
+      });
     });
   });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       axios:
         specifier: ^1.7.9
         version: 1.7.9
+      lettercoder:
+        specifier: ^0.1.1
+        version: 0.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1995,6 +1998,10 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
+  /base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -3524,6 +3531,12 @@ packages:
     dependencies:
       language-subtag-registry: 0.3.23
     dev: true
+
+  /lettercoder@0.1.1:
+    resolution: {integrity: sha512-htZUqrqbrRN6M7+K9kGZF59zLU08x9wCSrfb762FYbwwWU6/kcosR/jw4XG5AmsD1z6F4xQF9OGQ+ahoU3u22g==}
+    dependencies:
+      base64-js: 1.5.1
+    dev: false
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -15,9 +15,9 @@ export default {
       fontSize: {
         title: ["1.5rem", { fontWeight: "700" }],
         subtitle: ["1.25rem", { fontWeight: "600" }],
-        body: ["1rem", { fontWeight: "500" }],
-        label: ["0.875rem", { fontWeight: "500" }],
-        description: ["0.75rem", { fontWeight: "400" }],
+        label: ["1rem", { fontWeight: "500" }],
+        body: ["0.875rem", { fontWeight: "400" }],
+        description: ["0.75rem", { fontWeight: "300" }],
       },
     },
   },


### PR DESCRIPTION
## 🛠️ 구현한 부분

<!--
ex)
- [x] 카카오 로그인 API 연동
- [x] 구글 로그인 API 연동
-->

- [x] "현재 페이지 정보" 화면 퍼블리싱
- [x] url, title, html 정보를 가져오는 기능 구현

익스텐션에서 현재 보고 있는 페이지의 url, title, html 정보를 가져오는 기능을 구현하고 화면을 퍼블리싱했습니다.

## 🖼️ 실행 화면(선택)
<img width="1552" alt="스크린샷 2025-01-08 오후 8 52 43" src="https://github.com/user-attachments/assets/cdc37e70-2835-4802-9e3e-e11a3581bc3d" />

## 🔥 어려웠던 부분(선택)
- quoted-printable 문제로 인해 html 파일을 제대로 해석하지 못하는 부분이 어려웠습니다. 해당 문제는 [lettercoder](https://github.com/mat-sz/lettercoder)라는 라이브러리로 해결했습니다.

<!--
ex)
- 구글 로그인 관련 글이 많지 않아 소셜 로그인 연동 시 어려움이 있었습니다.
-->

## 🔍 참고(선택)

<!--
ex)
- [구글 로그인 관련 글](https://velog.io/~~)을 참고하여 구현했습니다.
-->
